### PR TITLE
Test jit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
 language: python
-python: 
+python:
     - "2.7"
+env:
+  - NUMBA_DISABLE_JIT=1
+
 before_install:
     - pip install coveralls
-install: 
+install:
     - pip install -r requirements.txt
     - pip install .
 
-script: 
+script:
     - coverage run --source hmmsort -m py.test
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
     - pip install .
 
 script:
-    - coverage run --source hmmsort -m py.test
+    - coverage run --source hmmsort -m py.test -s
 
 after_success:
     - coverage report


### PR DESCRIPTION
This allows coverage to be tracked for code is JIT'ed, at the expense of speed. This way, we get a better sense of what code is currently being covered by tests.