### PR TITLE
Check overlaps

### DIFF
--- a/hmm_decode.m
+++ b/hmm_decode.m
@@ -16,7 +16,10 @@
 
 function [mlseq,ll] = hmm_decode(varargin)
 
-Args = struct('SourceFile',[],'Channels',[],'save',0,'Group','','hdf5',0,'DescriptorFile',[],'hdf5Path',[],'spikeForms',[],'data',[],'reorder',[],'maxSize',[],'maxCells',30,'DataFile','','samplingRate',[],'fileName',[],'patchLength',[],'prob',[],'cinv',[],'outlierThreshold',4,'parseOutput',0, 'SaveFile', '');
+Args = struct('SourceFile',[],'Channels',[],'save',0,'Group','','hdf5',0,'DescriptorFile',[],'hdf5Path',[],...
+      'spikeForms',[],'data',[],'reorder',[],'maxSize',[],'maxCells',30,'DataFile','','samplingRate',[],...
+      'fileName',[],'patchLength',[],'prob',[],'cinv',[],'outlierThreshold',4,'parseOutput',0, 'SaveFile', '',...
+       '','scrubOverlapPatches',0);
 Args.flags = {'save','hdf5','parseOutput'};
 [Args,varargin] = getOptArgs(varargin,Args);
 % specify file to sort, should consist of:
@@ -307,6 +310,10 @@ try
 
 	% mlseq is an NxT array with the states of all N templates at each time
 	[mlseq,ll] = cutsort(data, spkform, cinv, patchlength, p);
+  if Args.scrubOverlapPatches
+      mlseq = scrubOverlaps(mlseq, cinv, spikeForms,data,4);
+  end
+
 	%save sequence to sorting file; if a source file was used, save to a file consistent with that name
 	if Args.save
 		if ~isempty(Args.SourceFile) || ~isempty(Args.SaveFile)

--- a/scrubOverlaps.m
+++ b/scrubOverlaps.m
@@ -1,0 +1,32 @@
+function mlseq = scrubOverlaps(mlseq, cinv, spikeForms, data, theta)
+  max_state = size(spikeForms,3);
+  noise_threshold = theta*sqrt(1/cinv);
+  %find portions with overlaps
+  oidx = find(sum(mlseq > 0,1)>1);
+  %start of each overlap
+  sidx = find(any(mlseq(:,oidx)==1,1));
+  %end of each overlap
+  eidx = find(any(mlseq(:,oidx)==max_state,1));
+  %loop through each overlap
+  nd = length(data);
+  for i = 1:length(eidx)
+    j = oidx(sidx(i));
+    %find the beginning of this section, i.e. the first point where
+    while j > 0 && any(mlseq(:,j))
+      j = j -1;
+    end
+    segment_start = j+1;
+    %find the end
+    j = oidx(eidx(i));
+    while j < nd && any(mlseq(:,j))
+      j = j + 1;
+    end
+    segment_end = j-1;
+    dd = data(segment_start:segment_end);
+    peak = max(abs(dd));
+    if peak < noise_threshold
+      %cancel the overlap
+      mlseq(:,segment_start:segment_end) = 0;
+    end
+  end
+end


### PR DESCRIPTION
This adds a matlab function scrubOverlaps that gets called by hmm_decode if requested. The function set mlseq to the silent state if a putative overlap segment does not exceed the noise threshold.